### PR TITLE
Fix clippy pedantic lint errors

### DIFF
--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -664,8 +664,7 @@ fn run_local_compose(local_dir: &str, args: &[&str]) -> DeployResult<()> {
 /// running.
 fn print_dnsmasq_hint() {
     let running = cmd::run("brew", &["services", "list"])
-        .map(|out| out.contains("dnsmasq") && out.contains("started"))
-        .unwrap_or(false);
+        .is_ok_and(|out| out.contains("dnsmasq") && out.contains("started"));
 
     if running {
         return;

--- a/tests/compose.rs
+++ b/tests/compose.rs
@@ -247,7 +247,7 @@ fn port_mapping_round_trip() {
             assert!(v.contains(&"4222:4222".to_string()));
             assert!(v.contains(&"8222:8222".to_string()));
         }
-        _ => panic!("expected short ports format"),
+        docker_compose_types::Ports::Long(_) => panic!("expected short ports format"),
     }
 }
 
@@ -274,7 +274,9 @@ fn caddy_only_depends_on_proxied_apps() {
             assert!(!deps.contains_key("nats"));
             assert!(!deps.contains_key("agent"));
         }
-        _ => panic!("expected conditional depends_on"),
+        docker_compose_types::DependsOnOptions::Simple(_) => {
+            panic!("expected conditional depends_on")
+        }
     }
 }
 
@@ -303,7 +305,9 @@ fn caddy_depends_on_all_routed_apps_only() {
             assert!(deps.contains_key("web"));
             assert!(!deps.contains_key("worker"));
         }
-        _ => panic!("expected conditional depends_on"),
+        docker_compose_types::DependsOnOptions::Simple(_) => {
+            panic!("expected conditional depends_on")
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Replace `.map(...).unwrap_or(false)` with `.is_ok_and(...)` in `src/pipeline.rs` (`clippy::map_unwrap_or`)
- Replace wildcard `_` match arms with explicit variant names in `tests/compose.rs` (`clippy::match_wildcard_for_single_variants`)

## Test plan

- [ ] CI lint job passes